### PR TITLE
Fix exception parameter name typo

### DIFF
--- a/CoreArchitecture.Business/EntityServices/_Base/BaseEntityService.cs
+++ b/CoreArchitecture.Business/EntityServices/_Base/BaseEntityService.cs
@@ -24,7 +24,7 @@ namespace CoreArchitecture.Business.EntityServices._Base
         {
             _repository = repository ?? throw new ArgumentNullException(nameof(repository));
             _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
-            _mapper = mapper ?? throw new ArgumentNullException(nameof(_mapper));
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
         }
 
         // GetById


### PR DESCRIPTION
## Summary
- correct constructor argument name in `BaseEntityService` when throwing `ArgumentNullException`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff9f6baf4832aae218f0852b0eed3